### PR TITLE
fix: remove gradle ecosystem from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: 'gradle'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 10
-
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary
- Remove `gradle` package ecosystem from Dependabot config
- The repo has no `build.gradle` or `build.gradle.kts` files, causing Dependabot to fail on every weekly run with: `Error during file fetching; aborting: No files found in /`

🤖 Generated with [Claude Code](https://claude.com/claude-code)