### PR TITLE
Add Claude Code GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,6 +2,7 @@ name: Claude Code
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, reopened, synchronize]
   issue_comment:
     types: [created]
@@ -10,8 +11,9 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'pull_request') ||
+    if: >-
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
         contains(github.event.comment.body, '@claude') &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
@@ -27,6 +29,6 @@ jobs:
       issues: write
     steps:
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds Claude Code GitHub Action workflow for automated PR reviews
- Triggers on PR open/sync and when @claude is mentioned in comments
- Requires `ANTHROPIC_API_KEY` secret to be configured in repo settings

## Setup Required
1. Add `ANTHROPIC_API_KEY` as a repository secret (Settings → Secrets and variables → Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated AI-assisted code review workflow that runs on pull requests and can be triggered via specific review comments to provide review assistance and annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->