### PR TITLE
ci: move Dependabot exclusion to step-level in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
       issues: write
     steps:
       - name: Run Claude Code
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
         uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Moves the `dependabot[bot]` check from the job-level `if` to a step-level `if` on the Claude Code action step
- The job now runs and reports SUCCESS for Dependabot PRs (with the Claude step skipped), instead of the entire job being skipped
- Fixes the issue where a skipped `claude` check doesn't satisfy required status checks in branch protection

## Context
The previous fix (job-level skip) caused the `claude` check to report as SKIPPED, which doesn't satisfy required status checks. This approach lets the job succeed while still skipping the expensive Claude action step.

## Test plan
- [ ] Verify Dependabot PRs get `claude: SUCCESS` (not SKIPPED)
- [ ] Verify non-Dependabot PRs still run Claude Code normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD workflow logic to improve handling of automated pull requests
  * Updated workflow action dependency to latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->