### PR TITLE
fix: add checkout step to Claude workflow for issue-triggered mode

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
       - name: Run Claude Code
         if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89


### PR DESCRIPTION
## Summary

- Adds `actions/checkout` step before `claude-code-action` so the runner has a git repository
- Issue-triggered runs were failing with `fatal: not a git repository`
- Uses org-standard pinned SHA (`actions/checkout@v6.0.2`)

## Test plan

- [ ] After merge, re-apply `claude` label to an issue and verify the workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)