### PR TITLE
feat: split Claude workflow into interactive + issue automation jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,6 +56,9 @@ jobs:
     if: >-
       github.event_name == 'issues' && github.event.action == 'labeled' &&
         github.event.label.name == 'claude'
+    concurrency:
+      group: claude-issue-${{ github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -80,7 +83,7 @@ jobs:
             actions: read
             checks: read
           claude_args: |
-            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run watch:*),Bash(cat:*),Edit,Write"
+            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh run view:*),Bash(gh run watch:*),Edit,Write"
           prompt: |
             Implement a fix for issue #${{ github.event.issue.number }}.
 


### PR DESCRIPTION
## Summary
- Splits the single `claude` job into two: `claude` (interactive PR reviews / @claude mentions) and `claude-issue` (issue-triggered automation).
- The `claude-issue` job runs in automation mode with scoped tools to create PRs, self-review, check CI, and tag code owners.
- Adds `actions: read` and `checks: read` permissions to both jobs.
- Aligns with the org standard at [petry-projects/.github ci-standards](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#4-claude-code-claudeyml).

## Test plan
- [ ] Verify `claude` job triggers on PRs and @claude mentions (not on issue labels).
- [ ] Verify `claude-issue` job triggers only when the `claude` label is added to an issue.
- [ ] Confirm CI permissions are correct for both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)