### PR TITLE
fix: add AGENTS.md with org-level standards reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Markets — Agent Standards
+
+> **Org-level standards:** This project follows the [petry-projects organization AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) which defines cross-cutting standards including TDD, SOLID, CLEAN, DRY, DDD, KISS, YAGNI, pre-commit checks, CI gates, BMAD workflows, and multi-agent isolation.
+
+> **Project-specific conventions:** See [Agents.md](Agents.md) for Markets-specific technology stack, component organization, styling rules, naming conventions, accessibility requirements, mobile UX constraints, and event-driven architecture rules.
+
+> **Detailed principle application:** See `_bmad-output/planning-artifacts/coding-standards.md` for bounded contexts, aggregates, typed IDs, test strategy, and coverage thresholds.


### PR DESCRIPTION
## Summary

- Creates `AGENTS.md` (all caps) at the repo root to satisfy the `agents-md-missing-org-ref` compliance check
- The project already had `Agents.md` (mixed case) with the org reference, but the compliance audit specifically checks for `AGENTS.md` (all caps)
- `AGENTS.md` explicitly references the [petry-projects org AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) and delegates to `Agents.md` for project-specific conventions

## Test plan

- [ ] Verify `AGENTS.md` exists at repo root
- [ ] Verify `AGENTS.md` contains reference to `https://github.com/petry-projects/.github/blob/main/AGENTS.md`
- [ ] Confirm compliance audit no longer flags `agents-md-missing-org-ref` after merge

Closes #60

Generated with [Claude Code](https://claude.ai/code)