### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS
+# This file defines code owners for this repository.
+# Code owners are automatically requested for review when someone opens a PR
+# that modifies code they own.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for all files
+* @don-petry


### PR DESCRIPTION
Creates `.github/CODEOWNERS` to enforce code owner reviews on PRs.

Assigns `@don-petry` as the default owner for all files in the repository, resolving the `missing-codeowners` compliance finding.

Closes #52

Generated with [Claude Code](https://claude.ai/code)