### PR TITLE
fix: add code-quality repository ruleset setup script

### DIFF
--- a/.github/scripts/create-code-quality-ruleset.sh
+++ b/.github/scripts/create-code-quality-ruleset.sh
@@ -32,9 +32,9 @@ echo "==> Targeting repository: ${REPO}"
 # ---------------------------------------------------------------------------
 REQUIRED_CHECKS=$(cat <<'EOF'
 [
-  { "context": "Analyze",            "integration_id": null },
-  { "context": "SonarCloud",         "integration_id": null },
-  { "context": "Detect ecosystems",  "integration_id": null }
+  { "context": "Analyze" },
+  { "context": "SonarCloud" },
+  { "context": "Detect ecosystems" }
 ]
 EOF
 )
@@ -58,7 +58,6 @@ PAYLOAD=$(jq -n \
         type: "required_status_checks",
         parameters: {
           strict_required_status_checks_policy: false,
-          do_not_enforce_on_create: false,
           required_status_checks: $checks
         }
       }


### PR DESCRIPTION
## Summary

- Adds `.github/scripts/create-code-quality-ruleset.sh` — an idempotent script that creates (or updates) the `code-quality` repository ruleset required by the org standard
- The ruleset targets the default branch and enforces the following required status checks drawn from existing CI workflows:
  - `Analyze` (CodeQL — `.github/workflows/codeql.yml`)
  - `SonarCloud` (`.github/workflows/sonarcloud.yml`)
  - `Detect ecosystems` (Dependency audit — `.github/workflows/dependency-audit.yml`)

## Why a script instead of automated creation?

Creating a repository ruleset requires `administration:write` permission. The Claude Code workflow token does not have (and should not have) admin access. A **repo admin** must run this script once with an appropriately scoped token:

```bash
export GH_TOKEN=<admin-token>
bash .github/scripts/create-code-quality-ruleset.sh
```

The script is safe to re-run — it detects an existing ruleset by name and updates it rather than creating a duplicate.

## Closes #51

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated code quality ruleset management to consistently enforce required status checks across the repository's default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->