### PR TITLE
feat: adopt org-wide feature-ideation reusable workflow

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -1,0 +1,75 @@
+# Feature Ideation — markets caller stub.
+#
+# Calls the org-wide reusable workflow at
+# petry-projects/.github/.github/workflows/feature-ideation-reusable.yml
+# All ideation logic, the multi-skill pipeline, the Opus 4.6 model
+# selection, and the github_token override live in the reusable workflow.
+#
+# To tune the prompt or pipeline for ALL BMAD repos, edit the reusable
+# workflow in petry-projects/.github — changes propagate here on next run.
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos
+name: Feature Research & Ideation (BMAD Analyst)
+
+on:
+  schedule:
+    - cron: '0 7 * * 5'   # Friday 07:00 UTC (3 AM EDT / 2 AM EST)
+  workflow_dispatch:
+    inputs:
+      focus_area:
+        description: 'Optional focus area (e.g., "vendor onboarding", "real-time updates", "manager UX")'
+        required: false
+        type: string
+      research_depth:
+        description: 'Research depth'
+        required: false
+        default: 'standard'
+        type: choice
+        options:
+          - quick
+          - standard
+          - deep
+
+permissions: {}
+
+concurrency:
+  group: feature-ideation
+  cancel-in-progress: false
+
+jobs:
+  ideate:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      discussions: write
+      id-token: write
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@main
+    with:
+      project_context: |
+        markets is a real-time market operations platform for local farmer
+        and art markets, serving three sides: market managers (who validate
+        and publish day-of information), vendors (who report status and
+        product availability with minimal friction), and customers (who
+        need accurate market hours, location, and what's on offer before
+        and during their visit). The product replaces the fragmented
+        text/email/phone/social-media coordination workflow that managers
+        and vendors use today. Stack: React + GraphQL + Supabase, mobile-
+        first PWA-friendly UX.
+
+        Adjacent / competitor space: Instagram and Facebook for ad-hoc
+        market updates; generic event platforms (Eventbrite); farmers-
+        market-specific apps (Farmstand, LocalHarvest, Square Market);
+        vendor management SaaS (Manage My Market, MarketWurks). None
+        provide a real-time, three-sided coordination layer optimized for
+        market-day execution.
+
+        Trends to research: real-time object detection / vision models for
+        vendor inventory capture, low-friction structured reporting for
+        non-technical vendors, hyperlocal commerce trust signals,
+        regenerative ag and farm-to-table consumer expectations, vendor
+        payment/POS integrations, civic/municipal market partnerships.
+      focus_area: ${{ inputs.focus_area || '' }}
+      research_depth: ${{ inputs.research_depth || 'standard' }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Adopts the org-wide BMAD Analyst (Mary) feature-research-and-ideation workflow as a thin caller stub. The reusable workflow lives at [petry-projects/.github](https://github.com/petry-projects/.github/blob/main/.github/workflows/feature-ideation-reusable.yml) — this repo only customizes the `project_context` paragraph that tells Mary what the project is and what competitive landscape to research.

Standard: [ci-standards.md §8](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos)

## Schedule

Runs every Friday at 07:00 UTC (3 AM EDT / 2 AM EST). Manually dispatchable via the Actions tab with optional `focus_area` and `research_depth` (quick / standard / deep) inputs.

## What it produces

Each run executes a 5-phase multi-skill pipeline on Claude Opus 4.6:

1. **Market Research** — iterative evidence gathering via web search
2. **Brainstorming** — 8-15 raw ideas, divergent
3. **Party Mode** — collaborative refinement, scoring on Feasibility / Impact / Urgency
4. **Adversarial** — 5-question stress test (only survivors are proposed)
5. **Publish** — creates one Discussion in the Ideas category per surviving proposal, with Adversarial Review section

Typical cost: ~$2-3 per run on Opus 4.6 standard depth.

## Test plan

- [x] YAML validates locally
- [x] Reusable workflow already proven in TalkTerm pilot (runs #3 and #4)
- [ ] First scheduled or manual run produces sensible Discussions in the Ideas category

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated feature research workflow with weekly scheduling and manual trigger support for flexible research depth configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->