### PR TITLE
fix: pin dtolnay/rust-toolchain to SHA in dependency-audit.yml

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -122,7 +122,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@b3b07ba8eba0da7e97e29f82c60808e09c43a28e # stable
+        with:
+          toolchain: stable
 
       - name: Install cargo-audit
         run: cargo install cargo-audit@0.21.1 --locked


### PR DESCRIPTION
## Summary

- Pins `dtolnay/rust-toolchain@stable` to commit SHA `b3b07ba8eba0da7e97e29f82c60808e09c43a28e` in `.github/workflows/dependency-audit.yml`
- Adds explicit `toolchain: stable` input (required when using a SHA pin, since the action normally infers the channel from the ref name)
- Brings the repository into compliance with the org-wide [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)

Closes #47

Generated with [Claude Code](https://claude.ai/code)