### PR TITLE
feat: add agent-shield.yml compliance workflow

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,0 +1,21 @@
+# Agent Shield — thin caller that delegates to the org-level reusable workflow.
+# All logic is maintained centrally in agent-shield-reusable.yml.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#required-workflows
+name: Agent Shield
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  agent-shield:
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: read


### PR DESCRIPTION
## Summary

- Adds the required `agent-shield.yml` workflow as a thin caller delegating to the org-level reusable workflow (`agent-shield-reusable.yml`)
- Follows the same pattern as other thin-caller workflows in this repo (e.g., `claude.yml`, `feature-ideation.yml`)
- Brings the repository into compliance with [ci-standards.md#required-workflows](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#required-workflows)

## Changes

- `.github/workflows/agent-shield.yml` — new thin-caller workflow

Closes #57

Generated with [Claude Code](https://claude.ai/code)