### PR TITLE
fix: replace dtolnay/rust-toolchain with rustup in dependency-audit.yml

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,4 +1,5 @@
 # Dependency vulnerability audit
+# Copy to .github/workflows/dependency-audit.yml
 #
 # Auto-detects ecosystems present in the repository and runs the appropriate
 # audit tool. Fails the build if any dependency has a known security advisory.
@@ -6,7 +7,7 @@
 # Add "dependency-audit" as a required status check in branch protection.
 #
 # Pinned tool versions (update deliberately):
-#   govulncheck v1.1.4 | cargo-audit 0.21.1 | pip-audit 2.9.0
+#   govulncheck v1.1.4 | cargo-audit 0.22.1 | pip-audit 2.9.0
 name: Dependency audit
 
 on:
@@ -24,11 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       npm: ${{ steps.check.outputs.npm }}
+      pnpm: ${{ steps.check.outputs.pnpm }}
       gomod: ${{ steps.check.outputs.gomod }}
       cargo: ${{ steps.check.outputs.cargo }}
       pip: ${{ steps.check.outputs.pip }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect package ecosystems
         id: check
@@ -38,6 +40,13 @@ jobs:
             echo "npm=true" >> "$GITHUB_OUTPUT"
           else
             echo "npm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # pnpm — look for pnpm-lock.yaml anywhere
+          if find . -name 'pnpm-lock.yaml' -not -path '*/node_modules/*' | grep -q .; then
+            echo "pnpm=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pnpm=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Go modules — detect via go.mod (not go.sum, which may not exist)
@@ -68,9 +77,9 @@ jobs:
     if: needs.detect.outputs.npm == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "lts/*"
 
@@ -87,15 +96,42 @@ jobs:
           done < <(find . -name 'package-lock.json' -not -path '*/node_modules/*' -exec dirname {} \;)
           exit $status
 
+  audit-pnpm:
+    name: pnpm audit
+    needs: detect
+    if: needs.detect.outputs.pnpm == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "lts/*"
+
+      - name: Audit pnpm dependencies
+        run: |
+          # Audit each pnpm-lock.yaml found in the repo
+          status=0
+          while IFS= read -r dir; do
+            echo "::group::pnpm audit $dir"
+            if ! (cd "$dir" && pnpm audit --audit-level low); then
+              status=1
+            fi
+            echo "::endgroup::"
+          done < <(find . -name 'pnpm-lock.yaml' -not -path '*/node_modules/*' -exec dirname {} \;)
+          exit $status
+
   audit-go:
     name: govulncheck
     needs: detect
     if: needs.detect.outputs.gomod == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
           go-version: "stable"
 
@@ -120,12 +156,13 @@ jobs:
     if: needs.detect.outputs.cargo == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust stable toolchain
+        run: rustup toolchain install stable --profile minimal
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit@0.21.1 --locked
+        run: cargo install cargo-audit@0.22.1 --locked
 
       - name: Audit Cargo dependencies
         run: |
@@ -147,7 +184,7 @@ jobs:
     if: needs.detect.outputs.pip == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:


### PR DESCRIPTION
## Summary

- Removes the unpinned external action `dtolnay/rust-toolchain@stable` (compliance finding #47)
- Replaces it with `rustup toolchain install stable --profile minimal` — a built-in command that requires no external action and no SHA pinning
- Syncs `dependency-audit.yml` with the latest org standards template (`petry-projects/.github/standards/workflows/dependency-audit.yml`), which also adds pnpm audit support and updates cargo-audit to 0.22.1

Closes #47

Generated with [Claude Code](https://claude.ai/code)