### PR TITLE
fix: add code-quality repository ruleset (closes #51)

### DIFF
--- a/.github/scripts/apply-code-quality-ruleset.sh
+++ b/.github/scripts/apply-code-quality-ruleset.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# apply-code-quality-ruleset.sh — Idempotently create/update the code-quality ruleset
+#
+# This script creates (or updates) the `code-quality` repository ruleset that
+# enforces required status checks on the default branch of petry-projects/markets.
+#
+# Required status checks configured (derived from actual CI check run names):
+#   - SonarCloud          sonarcloud.yml, job: sonarcloud (name: SonarCloud)
+#   - Analyze (actions)   codeql.yml, job: analyze (name: Analyze), language: actions
+#   - claude-code / claude  claude.yml, calling job: claude-code → reusable job: claude
+#
+# Standard reference:
+#   https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#code-quality--required-checks-ruleset-all-repositories
+#
+# Usage:
+#   GH_TOKEN=<admin-token> bash .github/scripts/apply-code-quality-ruleset.sh
+#
+# The org-level script (petry-projects/.github/scripts/apply-rulesets.sh) is the
+# canonical tool for managing rulesets across all repos. This script exists as a
+# repo-local reference and fallback for the markets repository specifically.
+
+set -euo pipefail
+
+REPO="petry-projects/markets"
+RULESET_NAME="code-quality"
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required with administration:write scope" >&2
+  exit 1
+fi
+
+export GH_TOKEN
+
+# Fetch existing rulesets
+EXISTING_ID=$(gh api "repos/$REPO/rulesets" \
+  --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || true)
+
+PAYLOAD=$(jq -n '{
+  name: "code-quality",
+  target: "branch",
+  enforcement: "active",
+  conditions: {
+    ref_name: {
+      include: ["~DEFAULT_BRANCH"],
+      exclude: []
+    }
+  },
+  rules: [
+    {
+      type: "required_status_checks",
+      parameters: {
+        strict_required_status_checks_policy: true,
+        required_status_checks: [
+          {context: "SonarCloud"},
+          {context: "Analyze (actions)"},
+          {context: "claude-code / claude"}
+        ]
+      }
+    }
+  ],
+  bypass_actors: []
+}')
+
+if [ -n "$EXISTING_ID" ]; then
+  echo "Updating existing $RULESET_NAME ruleset (id=$EXISTING_ID) ..."
+  echo "$PAYLOAD" | gh api -X PUT "repos/$REPO/rulesets/$EXISTING_ID" --input - > /dev/null
+  echo "Done — ruleset updated: https://github.com/$REPO/rules/$EXISTING_ID"
+else
+  echo "Creating $RULESET_NAME ruleset ..."
+  RESULT=$(echo "$PAYLOAD" | gh api -X POST "repos/$REPO/rulesets" --input -)
+  NEW_ID=$(echo "$RESULT" | jq -r '.id')
+  echo "Done — ruleset created: https://github.com/$REPO/rules/$NEW_ID"
+fi


### PR DESCRIPTION
## Summary

- Creates the required `code-quality` repository ruleset **directly via the GitHub API** (already active as of this PR — ruleset id `14805963`)
- Adds `.github/scripts/apply-code-quality-ruleset.sh` for idempotent future maintenance

## What was done

The `code-quality` ruleset is now live on `petry-projects/markets` and enforces these required status checks on the default branch:

| Check | Source |
|---|---|
| `SonarCloud` | `sonarcloud.yml`, job `sonarcloud` |
| `Analyze (actions)` | `codeql.yml`, matrix job `analyze` (actions ecosystem) |
| `claude-code / claude` | `claude.yml`, calling reusable workflow job |

Settings: `strict_required_status_checks_policy: true` (branch must be up to date before merging).

## Why a script in the repo?

The org-level [`apply-rulesets.sh`](https://github.com/petry-projects/.github/blob/main/scripts/apply-rulesets.sh) is the canonical tool for bulk management. This repo-local script exists as a reference and recovery tool specifically for markets — useful if the ruleset is accidentally deleted.

Closes #51

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure for automated code quality enforcement and compliance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->