### PR TITLE
ci: pin claude-code-reusable workflow to SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@208ec2d69b75227d375edf8745d84fbac05a76b2 # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to its exact commit SHA (`208ec2d69b75227d375edf8745d84fbac05a76b2 # v1`) to satisfy the org action-pinning policy.

## Changes

- `.github/workflows/claude.yml`: replaces `@v1` tag reference with the pinned SHA, with `# v1` comment for readability.

Closes #84

Generated with [Claude Code](https://claude.ai/code)