### PR TITLE
ci: pin claude-code-reusable workflow to SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,12 +31,14 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to `@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1`
- Adds the missing `check_run: [completed]` trigger to bring the file into full conformance with the standards template verbatim
- SHA resolved via `gh api repos/petry-projects/.github/git/refs/tags/v1`

Closes #84

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow automation configuration to pin the reusable workflow version to a specific release for enhanced stability.
  * Extended workflow triggers to activate on additional check completion events, improving automation responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->