### PR TITLE
docs(workflows): clarify intentional double .github/ in reusable-workflow paths

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,8 @@ permissions:
 
 jobs:
   agent-shield:
+    # NOTE: The double `.github/` is intentional. GitHub reusable-workflow path syntax is
+    # `{owner}/{repo}/{path}@{ref}`. The reusable lives at `.github/workflows/` within the
+    # `petry-projects/.github` repo, so the path is necessarily `.github/.github/workflows/`.
+    # This is NOT a duplicate — it is valid GitHub syntax. See ci-standards.md § Tier 1 stubs.
     uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    # NOTE: The double `.github/` is intentional. GitHub reusable-workflow path syntax is
+    # `{owner}/{repo}/{path}@{ref}`. The reusable lives at `.github/workflows/` within the
+    # `petry-projects/.github` repo, so the path is necessarily `.github/.github/workflows/`.
+    # This is NOT a duplicate — it is valid GitHub syntax. See ci-standards.md § Tier 1 stubs.
     uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds inline `# NOTE:` comments to `agent-shield.yml` and `dependabot-automerge.yml` explaining why the `petry-projects/.github/.github/workflows/` path is correct and intentional.
- The compliance check `reusable-workflow-path-duplicate-github` is a **false positive**: the "double `.github/`" is unavoidable valid GitHub syntax because reusable-workflow paths follow `{owner}/{repo}/{path}@{ref}`, and the org's reusables are stored at `.github/workflows/` inside the `petry-projects/.github` repo.
- No functional change — `uses:` lines are unchanged. Every other org repo (e.g. TalkTerm) and the canonical templates in `standards/workflows/` use the same path.

## Root cause

The automated compliance checker identifies any `uses:` path containing two `.github/` segments as a duplicate. For the special `.github` repository this pattern is structurally correct and cannot be avoided without breaking the workflow.

## Test plan

- [ ] Verify AgentShield and Dependabot auto-merge workflows still run successfully on this PR
- [ ] Confirm the next weekly compliance audit does **not** re-open this issue

Closes #136

Generated with [Claude Code](https://claude.ai/code)