### PR TITLE
fix: correct reusable workflow path (remove duplicate .github/)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/workflows/claude-code-reusable.yml@v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Fixes the broken reusable workflow reference syntax introduced by incorrect template.

Changed from: `petry-projects/.github/.github/workflows/claude-code-reusable.yml`
Changed to: `petry-projects/.github/workflows/claude-code-reusable.yml`

This path was preventing the claude-code check from running.

The correct GitHub Actions syntax for calling a reusable from another repo:
- owner/repo = the source repository
- /path/to/workflow = path within that repo

Related: https://github.com/petry-projects/.github/pull/154