### PR TITLE
Revert: Restore required double .github/ in reusable workflow paths

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
This reverts the broken fix that removed the required double .github/ segment.

The correct format for reusable workflow references is:
```
owner/repository/.github/workflows/name.yml
```

Where 'repository' is the actual repository name (e.g., '.github'), not a path segment.