### PR TITLE
ci: add auto-rebase workflow and check_run trigger to claude.yml

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,42 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/auto-rebase.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/auto-rebase-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All branch-update logic lives in the
+#     reusable workflow above.
+#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
+#     workflow version (bump SHA to latest main of petry-projects/.github).
+#   • You MUST NOT change: trigger event, the concurrency group name,
+#     or the job-level `permissions:` block — reusable workflows can be
+#     granted no more permissions than the calling job has, so removing
+#     the stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Auto-rebase non-Dependabot PRs — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/auto-rebase.yml in your repo.
+# No secrets required — uses GITHUB_TOKEN only.
+name: Auto-rebase non-Dependabot PRs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: auto-rebase
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  auto-rebase:
+    permissions:
+      contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write # post comments on PRs
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
+    secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,8 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- Adds `check_run: types: [completed]` trigger to `claude.yml` so the `claude-ci-fix` job in the org reusable can respond to CI failures on open PRs automatically
- Adds `auto-rebase.yml` thin caller stub to keep PRs up-to-date with `main` after every merge

Both workflows are part of the org standard. See [petry-projects/.github#157](https://github.com/petry-projects/.github/pull/157) and [petry-projects/.github#158](https://github.com/petry-projects/.github/pull/158).