### PR TITLE
fix: update reusable SHA to fix CI trigger on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -21,7 +21,7 @@
 # Dependabot update-and-merge — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/dependabot-rebase.yml in your repo.
 # Required org secrets (passed explicitly):
-#   APP_ID         — GitHub App ID with contents:write and pull-requests:write
+#   APP_ID         — GitHub App ID with pull-requests:write
 #   APP_PRIVATE_KEY — GitHub App private key
 name: Dependabot update and merge
 
@@ -40,9 +40,8 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      contents: write # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
-      pull-requests: write # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@2f6d246fd7cc8740f5d7e2e4d12f087889c58365 # v1
+      pull-requests: write # post @dependabot rebase comments and re-approve PRs
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@3ac78a9b0a7b5bcf0b9a62c284129f3abffdebaa # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Updates `dependabot-rebase.yml` to reference the new reusable workflow SHA (`3ac78a9b`).

**Root cause:** The reusable workflow was using the GitHub API `update-branch` endpoint with `GITHUB_TOKEN`. GitHub's recursive-trigger guard prevents `GITHUB_TOKEN`-triggered events from starting new workflow runs. Required checks (SonarCloud, build-and-test, etc.) never ran on the updated PR commits, so PRs stayed `BLOCKED` indefinitely.

**Fix:** The new reusable posts `@dependabot rebase` instead. Dependabot's own push triggers CI normally.

Also removes the now-unnecessary `contents: write` permission from the job's permissions block.