### PR TITLE
chore: standardize CODEOWNERS on @petry-projects/org-leads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,5 @@
 # CODEOWNERS
-# This file defines code owners for this repository.
-# Code owners are automatically requested for review when someone opens a PR
-# that modifies code they own.
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Standard: use the @petry-projects/org-leads team for all code owner
+# assignments. See petry-projects/.github standards/codeowners-standard.md
 
-# Default owner for all files
-* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
+* @petry-projects/org-leads


### PR DESCRIPTION
Per the [org CODEOWNERS standard](https://github.com/petry-projects/.github/blob/main/standards/codeowners-standard.md), replace individual user/bot listings with the `@petry-projects/org-leads` team.

This unblocks repos with `require_code_owner_review: true` once the machine user `@donpetry-bot` is in the team.

Closes the CODEOWNERS gap from [pr-review-agent#27](https://github.com/don-petry/pr-review-agent/issues/27).