### PR TITLE
docs(codeowners): tighten comment to match org standard format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# CODEOWNERS
-# Standard: use the @petry-projects/org-leads team for all code owner
-# assignments. See petry-projects/.github standards/codeowners-standard.md
+# CODEOWNERS — see petry-projects/.github standards/codeowners-standard.md
+# Rule: @petry-projects/org-leads MUST be the first owner on every line.
 
+# Default — all paths
 * @petry-projects/org-leads


### PR DESCRIPTION
## Summary

The weekly compliance audit (issue #155) flagged `codeowners-org-leads-not-first` with 404 responses for all three CODEOWNERS lookup paths, indicating the file was missing when the audit ran. PR #153 had already merged the correct CODEOWNERS on 2026-05-04, so the repo is already compliant.

This PR:
- Updates the CODEOWNERS header comment to be more concise and align with the recommended style in the org standard (`petry-projects/.github/standards/codeowners-standard.md`)
- Makes explicit that `@petry-projects/org-leads` must be first on every owner line
- Keeps the single `* @petry-projects/org-leads` rule intact (already correct)

Closes #155

Generated with [Claude Code](https://claude.ai/code)