### PR TITLE
docs(codeowners): add explicit catch-all comment (closes #156)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # CODEOWNERS — see petry-projects/.github standards/codeowners-standard.md
 # Rule: @petry-projects/org-leads MUST be the first owner on every line.
 
-# Default — all paths
+# Default catch-all — ensures every file has an owner so
+# require_code_owner_review applies to all paths.
 * @petry-projects/org-leads


### PR DESCRIPTION
## Summary

The weekly compliance audit (2026-05-08) raised issue #156 (`codeowners-no-catchall`), but the `*` catch-all was already present in `main` — the audit received 404 responses for all three CODEOWNERS lookup paths during that run (the same root cause as issue #155, which is addressed by PR #160).

This PR makes the intent of the catch-all explicit through a descriptive comment, so future audits can confirm at a glance that:
- Every file has an owner via the `*` pattern
- `require_code_owner_review` applies to all paths

**No functional change** — the `* @petry-projects/org-leads` rule was already in place.

Closes #156

## Test plan

- [ ] Verify `.github/CODEOWNERS` contains `*` as first pattern — ✅ already present
- [ ] Confirm compliance audit's `codeowners-no-catchall` check passes on next run

Generated with [Claude Code](https://claude.ai/code)