### PR TITLE
feat(concurrency): add per-repo serialized concurrency to dev-lead

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -37,6 +37,16 @@ on:
 
 permissions: {}
 
+concurrency:
+  # One active run per repo; ci-relay (check_run) keeps an ephemeral per-SHA slot
+  # so it can fire immediately without blocking or being blocked by the dispatch queue.
+  group: >-
+    ${{
+      github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
+      'dev-lead'
+    }}
+  cancel-in-progress: false
+
 jobs:
   dev-lead:
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main


### PR DESCRIPTION
## Summary

- Adds a `concurrency:` block to `.github/workflows/dev-lead.yml` so at most one dev-lead dispatch run executes in this repo at a time; new triggers queue with `cancel-in-progress: false`
- The `ci-relay` (`check_run`) path retains its ephemeral per-SHA slot
- Mirrors the org-wide policy from petry-projects/.github-private and the updated stub template in petry-projects/.github

## Why

Previously there was no concurrency control on this caller stub, meaning parallel PR events could spin up multiple simultaneous dev-lead agents competing for the same rate-limit budget.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify dev-lead runs queue (not stack) when multiple PR events fire simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)