### PR TITLE
feat(copilot): add repo-level Copilot instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,79 @@
+# Copilot Instructions — markets
+
+> **Note:** This file applies to the `petry-projects/markets` repository only. Org-wide rules are in [`petry-projects/.github/copilot-instructions.md`](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md). This file covers only what is specific to markets.
+
+## About
+
+Markets is a real-time coordination platform for local farmers markets — a mobile-first (iOS/Android/web) app with three user roles (Customer, Vendor, Market Manager), built with Expo + Go and using Firebase for auth and real-time updates.
+
+## Tech Stack
+
+- **Runtime:** Node.js (mobile/frontend) · Go on GCP Cloud Run (backend)
+- **Framework:** React Native / Expo SDK 55 · TypeScript · Expo Router (file-based) · Gluestack UI v3 · NativeWind v4
+- **Backend:** Go · gqlgen (GraphQL) · Cloud SQL PostgreSQL · Firebase Auth · Firebase Realtime Database
+- **Testing:** Jest (jest-expo preset) · `go test ./...`
+- **Linting:** ESLint + Prettier (mobile) · `golangci-lint` (Go)
+- **Key libraries:** Apollo Client 4.x · `@graphql-codegen` · MMKV (offline queue) · `expo-notifications` (FCM) · `expo-image`
+
+## Project Structure
+
+```text
+app/
+  (auth)/              # Login, role selection
+  (customer)/          # Customer tabs: discover, following, profile
+  (vendor)/            # Vendor tabs: markets, status, profile
+  (manager)/           # Manager tabs: dashboard, vendors, profile
+  _layout.tsx          # Root layout: auth gate + role-based routing
+components/
+  gluestack-ui-provider/  # Gluestack theme provider + config.ts (design tokens)
+  ui/                     # Gluestack UI base components (added via CLI — do not hand-edit)
+  market/   vendor/   checkin/   search/   activity/   freshness/   settings/
+hooks/                 # Custom hooks (use prefix, e.g. useVendorStatus.ts)
+lib/
+  apollo.ts            # Apollo Client configuration
+  firebase.ts          # Firebase Auth + Realtime config
+  mmkv.ts              # MMKV offline queue utilities
+graphql/
+  queries/   mutations/   # .graphql source files
+  generated/               # @graphql-codegen output — never edit manually
+constants/             # Theme tokens, config values
+assets/                # Images, fonts
+```
+
+## Local Dev Commands
+
+- Install:      `npm install`
+- Mobile dev:   `npx expo start`
+- Test:         `npm test`
+- Lint:         `npm run lint`
+- Typecheck:    `npx tsc --noEmit`
+- Codegen:      `npm run codegen` (regenerates `graphql/generated/`)
+
+## Required Environment Variables
+
+- `FIREBASE_API_KEY`: Firebase web API key
+- `FIREBASE_AUTH_DOMAIN`: Firebase auth domain
+- `FIREBASE_PROJECT_ID`: GCP project ID
+- `FIREBASE_REALTIME_DB_URL`: Firebase Realtime Database URL
+- `GRAPHQL_URL`: GraphQL API endpoint (GCP Cloud Run URL)
+
+## Testing Framework
+
+- Mobile runner: Jest with jest-expo preset
+- Backend runner: `go test ./...` with `golangci-lint run`
+- Coverage thresholds: see `_bmad-output/planning-artifacts/coding-standards.md`
+- Mutation testing: not configured
+
+## Repo-Specific Overrides
+
+**Figma-driven UI development:** Use Figma MCP (file key `LMawgHcglco0TG32UAQUhE`) for all UI work — run `get_design_context` before coding, validate against `get_screenshot` after. Translate Figma Tailwind/HTML output to Gluestack UI v3 + NativeWind equivalents (e.g. `<div>` → `<Box>`, `<button>` → `<Button>+<ButtonText>`).
+
+**Never hardcode colors** — always use design tokens from `components/gluestack-ui-provider/config.ts` referenced via `tailwind.config.js`.
+
+**Generated code** — never edit `graphql/generated/` directly; run `npm run codegen` to regenerate.
+
+**Role-based routing** — customer screens in `app/(customer)/`, vendor in `app/(vendor)/`, manager in `app/(manager)/`.
+
+## Org Standards
+
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,7 +80,7 @@ See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.gi
 
 **Language-specific instructions** (applied automatically by Copilot when you open matching file types):
 
-- [TypeScript / TSX](.github/instructions/typescript.instructions.md) — strict config, branded types, DDD/CQRS patterns, React Native, pino logging
-- [JavaScript](.github/instructions/javascript.instructions.md) — style, JSDoc type annotations, error handling
-- [Go](.github/instructions/go.instructions.md) — naming, gofmt, slog logging, error wrapping, concurrency, testing
-- [Shell](.github/instructions/shell.instructions.md) — safety flags, ShellCheck, quoting, error handling
+- [TypeScript / TSX](./instructions/typescript.instructions.md) — strict config, branded types, DDD/CQRS patterns, React Native, pino logging
+- [JavaScript](./instructions/javascript.instructions.md) — style, JSDoc type annotations, error handling
+- [Go](./instructions/go.instructions.md) — naming, gofmt, slog logging, error wrapping, concurrency, testing
+- [Shell](./instructions/shell.instructions.md) — safety flags, ShellCheck, quoting, error handling

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,4 +76,11 @@ assets/                # Images, fonts
 
 ## Org Standards
 
-See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md).
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) for org-wide development standards.
+
+**Language-specific instructions** (applied automatically by Copilot when you open matching file types):
+
+- [TypeScript / TSX](.github/instructions/typescript.instructions.md) — strict config, branded types, DDD/CQRS patterns, React Native, pino logging
+- [JavaScript](.github/instructions/javascript.instructions.md) — style, JSDoc type annotations, error handling
+- [Go](.github/instructions/go.instructions.md) — naming, gofmt, slog logging, error wrapping, concurrency, testing
+- [Shell](.github/instructions/shell.instructions.md) — safety flags, ShellCheck, quoting, error handling

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,154 @@
+---
+description: Go development standards for the Petry Projects organization, based on Effective Go and Google's Go Style Guide
+applyTo: "**/*.go"
+---
+
+# Go Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. They are based on
+[Effective Go](https://go.dev/doc/effective_go),
+[Go Code Review Comments](https://go.dev/wiki/CodeReviewComments), and
+[Google's Go Style Guide](https://google.github.io/styleguide/go/). Go is used for
+infrastructure tools, CLI utilities, and backend services in this org.
+
+## General Principles
+
+- Write simple, clear, and idiomatic Go. Favor clarity over cleverness.
+- Keep the happy path left-aligned — return early to reduce nesting.
+- Make the zero value useful. Design types so the zero value is a valid, safe starting state.
+- Prefer the standard library over third-party packages when equivalent functionality exists.
+- Use Go modules (`go.mod` / `go.sum`) for all dependency management.
+
+## Naming Conventions
+
+- Package names: lowercase, single-word, no underscores or hyphens. Singular, not plural.
+  Avoid generic names (`util`, `common`, `base`, `helper`).
+- Variables and functions: `camelCase`. Exported symbols: `PascalCase`.
+- Interfaces: `-er` suffix when describing a single behavior (`Reader`, `Writer`, `Formatter`).
+  Keep interfaces small (1–3 methods is ideal).
+- **Each Go file must have exactly ONE `package` declaration.** When editing an existing file,
+  preserve the existing declaration. When creating a new file, check the package names of
+  sibling files first.
+
+## Code Style
+
+- Always format with `gofmt` (or `goimports`). This is non-negotiable.
+- Use `goimports` to manage import blocks automatically.
+- Write comments in English. Document all exported symbols — start with the symbol name.
+  Comment the *why*, not the *what*, unless the logic is complex.
+- Avoid emoji in code and comments.
+
+## Error Handling
+
+- Check errors immediately after every function call. Never ignore with `_` without a comment.
+- Wrap errors with context: `fmt.Errorf("operation description: %w", err)`.
+- Place error returns as the last return value, named `err`.
+- Use `errors.Is` / `errors.As` for error checking, not string comparison.
+- Log errors at the point of handling — not at every intermediate propagation layer. Add context
+  by wrapping, then log once at the top-level handler.
+- Error messages: lowercase, no trailing punctuation.
+
+## Project Structure
+
+Follow standard Go project layout:
+
+```text
+cmd/           # Application entry points (one directory per binary)
+internal/      # Private packages (not importable by external projects)
+pkg/           # Reusable packages safe for external import
+```
+
+Avoid circular dependencies. Use `internal/` for packages that should not be imported outside
+the module. Group related functionality into focused packages.
+
+## Structured Logging
+
+Use **`log/slog`** (Go 1.21+) as the default structured logger:
+
+```go
+import (
+    "log/slog"
+    "os"
+)
+
+// Wire up once at program start (e.g., main.go).
+// Production — structured JSON for log aggregation:
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+// Development — swap the handler for human-readable text:
+// logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+// Propagate the logger via context so OpenTelemetry can bridge trace/span IDs:
+logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
+```
+
+- **Never use the global `log` package** from the standard library.
+- Propagate loggers via `context.Context`. Use `slog.InfoContext(ctx, ...)` so trace/span IDs
+  are automatically bridged.
+- In tests, suppress output: `slog.New(slog.NewTextHandler(io.Discard, nil))`.
+- Log at the point of handling, not at every layer. Wrap errors with `fmt.Errorf` and log once.
+- Never log variables named `password`, `secret`, `token`, `api_key`, `private_key`,
+  `authorization`, or `cookie`.
+
+## Concurrency
+
+- Be cautious about creating goroutines in libraries; prefer letting the caller control
+  concurrency.
+- Always know how a goroutine will exit. Use `sync.WaitGroup` or channels to wait for
+  goroutines. Avoid goroutine leaks.
+- Use channels for communication between goroutines; use `sync.Mutex` for protecting shared
+  state.
+- Close channels from the sender side only.
+- WaitGroup pattern:
+  - Go ≥ 1.25: `sync.WaitGroup` gains a `Go(fn func())` method — use `wg.Go(fn)` directly.
+  - Go < 1.25: use the classic `wg.Add(1)` / `defer wg.Done()` pattern.
+  - For error propagation across goroutines, prefer `golang.org/x/sync/errgroup` (`eg.Go(fn)`) over bare `sync.WaitGroup`.
+
+## HTTP Clients and I/O
+
+- HTTP client structs hold configuration only (base URL, `*http.Client`, auth, default headers).
+  Never store per-request state on the client struct.
+- Construct a fresh `*http.Request` per method call. Never cache or reuse a request object.
+- Always close response bodies: `defer resp.Body.Close()`.
+- `io.Reader` streams are consumable once. To read a body multiple times, use `io.ReadAll` once
+  and create fresh readers: `bytes.NewReader(buf)`.
+- Set `req.GetBody` for retryable requests so the transport can recreate the body.
+
+## HTTP Server (net/http)
+
+- Go ≥ 1.22: use the enhanced `net/http` `ServeMux` with method + pattern routing.
+- Go < 1.22: handle methods manually in handlers or use a justified third-party router.
+
+## Type Safety
+
+- Prefer explicit type conversions. Use `any` (Go 1.18+) instead of `interface{}`.
+- Use generics over unconstrained types. Prefer specific type constraints when possible.
+- Use type assertions carefully — always check the second return value:
+  `v, ok := x.(SomeType); if !ok { ... }`.
+
+## Testing
+
+- Use table-driven tests with `t.Run` subtests.
+- Name tests: `Test_FunctionName_Scenario` or `TestFunctionName`.
+- Mark helper functions with `t.Helper()`. Use `t.Cleanup()` for teardown.
+- Place test files next to source (`service.go` → `service_test.go`).
+- White-box tests use the same package; black-box tests use the `_test` package suffix.
+- Use `testify/assert` when it adds clarity, but avoid over-complicating simple assertions.
+
+## Security
+
+- Validate all external input at system boundaries.
+- Use `crypto/rand` for random number generation. Never use `math/rand` for security-sensitive
+  operations.
+- Use standard library `crypto` packages — never implement cryptographic algorithms.
+- Store passwords with bcrypt, scrypt, or argon2 (`golang.org/x/crypto`).
+- Use TLS for all network communication.
+
+## Tooling
+
+- `go fmt` — format code (non-negotiable)
+- `go vet` — find suspicious constructs
+- `golangci-lint` — extended linting (replaces deprecated `golint`)
+- `go test ./...` — run all tests
+- `go mod tidy` — clean up unused dependencies
+
+Run `golangci-lint run` before committing. Zero warnings, zero errors.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -67,6 +67,7 @@ Use **`log/slog`** (Go 1.21+) as the default structured logger:
 
 ```go
 import (
+    "context"
     "log/slog"
     "os"
 )
@@ -77,13 +78,33 @@ logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 // Development — swap the handler for human-readable text:
 // logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
-// Propagate the logger via context so OpenTelemetry can bridge trace/span IDs:
-logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
+// Propagate the logger by attaching it to context; retrieve it where you log.
+// This keeps per-request fields (request_id, user_id) on the logger instance.
+type loggerKey struct{}
+
+func WithLogger(ctx context.Context, l *slog.Logger) context.Context {
+    return context.WithValue(ctx, loggerKey{}, l)
+}
+
+func FromContext(ctx context.Context) *slog.Logger {
+    if l, ok := ctx.Value(loggerKey{}).(*slog.Logger); ok {
+        return l
+    }
+    return slog.Default()
+}
+
+// Call the *propagated* logger (not slog.InfoContext, which dispatches via the
+// package-level default and bypasses per-request configuration). Using
+// InfoContext on the retrieved logger still bridges trace/span IDs:
+FromContext(ctx).InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
 ```
 
 - **Never use the global `log` package** from the standard library.
-- Propagate loggers via `context.Context`. Use `slog.InfoContext(ctx, ...)` so trace/span IDs
-  are automatically bridged.
+- Propagate loggers via `context.Context`. Call `InfoContext`/`ErrorContext` on the *retrieved*
+  logger (`FromContext(ctx).InfoContext(ctx, ...)`) so trace/span IDs are bridged **and**
+  per-request fields are preserved. Avoid the package-level helpers
+  (`slog.InfoContext`, `slog.ErrorContext`) — they dispatch via `slog.Default()` and bypass
+  any logger you attached to the context.
 - In tests, suppress output: `slog.New(slog.NewTextHandler(io.Discard, nil))`.
 - Log at the point of handling, not at every layer. Wrap errors with `fmt.Errorf` and log once.
 - Never log variables named `password`, `secret`, `token`, `api_key`, `private_key`,

--- a/.github/instructions/javascript.instructions.md
+++ b/.github/instructions/javascript.instructions.md
@@ -1,0 +1,52 @@
+---
+description: JavaScript development standards for the Petry Projects organization
+applyTo: "**/*.js,**/*.mjs,**/*.cjs"
+---
+
+# JavaScript Development Standards
+
+These rules extend the org-level `copilot-instructions.md` and apply to JavaScript files.
+
+> **Prefer TypeScript.** If a file can be migrated to TypeScript without significant disruption,
+> prefer the migration. JavaScript is accepted for configuration files (`eslint.config.js`,
+> `vite.config.mjs`, `jest.config.js`), build scripts, and legacy code during migration.
+
+## Style and Formatting
+
+- **Formatter:** Prettier. Run `prettier --write` before committing.
+- **Linter:** ESLint. Zero warnings, zero errors.
+- Never use `var`. Use `const` for all bindings that are not reassigned; use `let` only when
+  reassignment is required.
+- Prefer `async`/`await` over raw `.then()`/`.catch()` chains. Handle rejections — never leave
+  a floating promise.
+- Use ES modules (`import`/`export`) in all new code. CommonJS (`require`/`module.exports`) is
+  acceptable only in config files that require it.
+- Use destructuring assignment to extract values from objects and arrays.
+
+## Naming Conventions
+
+- `camelCase` for variables and functions. `PascalCase` for constructors and classes.
+  `SCREAMING_SNAKE_CASE` for module-level constants.
+- File names match the primary export or purpose (`orderService.js`, `eslint.config.mjs`).
+
+## Type Safety Without TypeScript
+
+- Use JSDoc annotations (`@param`, `@returns`, `@type`) in JavaScript files that cannot yet be
+  migrated, to enable IDE type inference and `checkJs` validation.
+- Enable `// @ts-check` at the top of critical JavaScript files to surface type errors in the
+  IDE without requiring full TypeScript migration.
+
+## Error Handling
+
+- Always handle Promise rejections — either with `try`/`catch` in `async` functions or with an
+  explicit `.catch()` handler.
+- Never use empty catch blocks (`catch (e) {}`). At minimum, log the error with structured
+  fields.
+- Do not use `console.log` in application or library code. Use a structured logger (`pino`).
+  `console.*` is acceptable only in CLI scripts and build tooling.
+
+## Testing
+
+- Follow the same TDD rules as TypeScript: write tests before implementing, never `.skip()`.
+- Use the same test runner as the rest of the project (Vitest or Jest).
+- Name tests as functional requirement specifications.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,139 @@
+---
+description: Shell script development standards for the Petry Projects organization
+applyTo: "**/*.sh,**/*.bash"
+---
+
+# Shell Script Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. Shell scripts are used for CI
+helper utilities, compliance automation, and infrastructure orchestration.
+
+## Safety Flags
+
+Every shell script MUST begin with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+- `set -e` — exit immediately on any command failure
+- `set -u` — treat unset variables as errors
+- `set -o pipefail` — propagate failures through pipelines (not just the last command)
+
+For scripts that intentionally handle errors inline (e.g., checking return codes manually),
+disable `set -e` locally within a subshell or use `|| true` with a comment explaining why.
+
+## ShellCheck Compliance
+
+All scripts MUST pass `shellcheck` with zero warnings:
+
+```bash
+shellcheck --shell=bash <script>.sh
+```
+
+Run ShellCheck before committing. Common issues to fix proactively:
+
+- Unquoted variables — always quote: `"$variable"`, `"${array[@]}"`
+- Unsafe `$()` with user-controlled input — validate input first
+- Deprecated constructs — use `[[ ... ]]` over `[ ... ]` for bash conditionals
+
+## Quoting and Variable Expansion
+
+- **Always quote variable expansions:** `"$var"`, `"${var}"`, `"${array[@]}"`.
+- Use `${var:-default}` for safe defaults. Use `${var:?error message}` to fail fast on required
+  variables.
+- Use `$( )` for command substitution, not backticks.
+- Use `[[ ... ]]` for conditionals (bash built-in, safer than `[ ]`).
+- Use `(( ... ))` for arithmetic expressions.
+
+## Function Organization
+
+- Extract reusable logic into functions. Name functions with `snake_case`.
+- Declare local variables with `local` inside functions to avoid polluting global scope.
+- Functions that produce output should write to stdout. Functions that report errors should write
+  to stderr: `echo "Error: message" >&2`.
+
+  ```bash
+  log_info()  { echo "[INFO]  $*"; }
+  log_error() { echo "[ERROR] $*" >&2; }
+
+  process_item() {
+    local item="$1"
+    local output_dir="$2"
+    # ...
+  }
+  ```
+
+## Error Handling
+
+- Check return codes for commands that can fail silently (e.g., `curl`, `jq`, `aws`).
+- Use `|| { log_error "..."; exit 1; }` patterns to provide descriptive failure messages.
+- Use `trap 'cleanup' EXIT` to ensure cleanup runs even on error:
+
+  ```bash
+  cleanup() {
+    rm -f "$tmp_file"
+  }
+  trap 'cleanup' EXIT
+  ```
+
+## Command Injection Prevention
+
+- Never pass user-controlled input directly to shell commands without validation.
+- Use arrays to pass arguments to commands (avoids word-splitting and globbing):
+
+  ```bash
+  # Wrong — subject to word splitting:
+  run_command "$user_args"
+
+  # Right — use an array:
+  args=("--flag" "$user_value")
+  run_command "${args[@]}"
+  ```
+
+- Avoid `eval` with untrusted input.
+
+## Style and Readability
+
+- Use heredocs for multi-line strings instead of multiple `echo` statements:
+
+  ```bash
+  cat <<'EOF'
+  Usage: script.sh [options]
+    -h, --help    Show this help message
+  EOF
+  ```
+
+- Keep lines under 100 characters where practical. Use `\` to break long commands.
+- Add a one-line comment before each function and non-obvious command explaining *why*, not
+  *what*.
+- Use `readonly` for constants at the top of the script:
+
+  ```bash
+  readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  readonly MAX_RETRIES=3
+  ```
+
+## Makefile Standards
+
+- Use `.PHONY` for all non-file targets to prevent conflicts with files of the same name.
+- Use `$(MAKE)` recursively, not bare `make`.
+- Document each target with a `##` comment on the same line (enables `make help` patterns):
+
+  ```makefile
+  .PHONY: test lint
+
+  test: ## Run the full test suite with coverage
+  	go test ./... -coverprofile=coverage.out
+
+  lint: ## Run golangci-lint
+  	golangci-lint run
+  ```
+
+## Testing Shell Scripts
+
+- Test scripts with `bats` (Bash Automated Testing System) where feasible.
+- At minimum, test the happy path and common error paths.
+- Use `shellcheck` in CI as a required status check for repositories with significant shell
+  script surface area.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -55,8 +55,13 @@ Run ShellCheck before committing. Common issues to fix proactively:
   to stderr: `echo "Error: message" >&2`.
 
   ```bash
-  log_info()  { echo "[INFO]  $*"; }
-  log_error() { echo "[ERROR] $*" >&2; }
+  # Quote "$*" so the joined message is treated as a single argument
+  # (without quoting, word-splitting and globbing would apply).
+  log_info()  { printf '[INFO]  %s\n' "$*"; }
+  log_error() { printf '[ERROR] %s\n' "$*" >&2; }
+
+  # When forwarding to another command, use "$@" to preserve argument boundaries:
+  run_quietly() { "$@" >/dev/null 2>&1; }
 
   process_item() {
     local item="$1"

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,140 @@
+---
+description: TypeScript and TSX development standards for the Petry Projects organization
+applyTo: "**/*.ts,**/*.tsx"
+---
+
+# TypeScript Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. TypeScript is the primary language
+across all Petry Projects repositories.
+
+## Compiler Configuration
+
+Always use TypeScript in strict mode. All repositories MUST include these flags (or stricter):
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true
+  }
+}
+```
+
+Never use `// @ts-ignore` or `// @ts-expect-error` to silence type errors without a documented
+reason. Fix the underlying type issue instead.
+
+## Code Style
+
+- **Formatter:** Prettier with `singleQuote: true`, `semi: true`, `trailingComma: "all"`,
+  `printWidth: 100`, `tabWidth: 2`. Run `prettier --write` before committing.
+- **Linter:** ESLint flat config (`eslint.config.mjs`). Zero warnings, zero errors.
+- **Imports:** Use `import type { ... }` for type-only imports. Organize imports: external
+  packages first, then internal modules. No circular imports.
+- **No barrel files.** Avoid `index.ts` re-export files unless the project explicitly requires
+  them — they increase circular dependency risk and slow down bundlers.
+- **Naming:** `PascalCase` for types, interfaces, classes, and React components. `camelCase` for
+  variables, functions, and methods. `SCREAMING_SNAKE_CASE` for module-level constants.
+  File names match the primary export (`UserRepository.ts`, `OrderSummary.tsx`).
+
+## Type Safety
+
+- Prefer `unknown` over `any`. When `any` is unavoidable, add a comment explaining why.
+- Use branded types / nominal typing for domain identifiers and value objects:
+
+  ```typescript
+  type UserId = string & { readonly __brand: "UserId" };
+  type OrderId = string & { readonly __brand: "OrderId" };
+  ```
+
+- Use discriminated unions instead of optional fields where possible.
+- Avoid type assertions (`as SomeType`) at system boundaries — validate with a type guard or
+  schema parser (e.g., Zod) instead.
+- Use `readonly` for arrays and object properties that should not be mutated.
+
+## Domain-Driven Design Patterns
+
+- **Ubiquitous language:** Use domain terminology from the bounded context in type names,
+  variable names, and method names. Never rename domain concepts to generic terms.
+- **Bounded contexts:** Each context lives in its own directory (e.g., `src/orders/`,
+  `src/billing/`). Cross-context dependencies use well-defined interfaces or domain events —
+  never direct internal imports across context boundaries.
+- **Aggregate roots:** External code accesses child entities only through the aggregate root.
+  Return domain objects from repositories, not raw database rows.
+- **Value objects:** Model domain quantities, identifiers, and domain-specific strings as value
+  objects. Validate on construction; throw on invalid input.
+- **Repository pattern:** Persistence is abstracted behind repository interfaces the domain
+  defines. Infrastructure implements them. Domain code never imports database drivers, ORMs, or
+  storage libraries.
+
+## CQRS Naming Conventions
+
+| Concept | Convention | Examples |
+|---------|-----------|----------|
+| Command | Imperative verb + noun | `PlaceOrder`, `CancelSubscription` |
+| Event | Past-tense verb + noun | `OrderPlaced`, `SubscriptionCancelled` |
+| Query | `Get` / `List` / `Search` + noun | `GetOrderById`, `ListActiveUsers` |
+| Command handler | `Handle(cmd)` or `<Name>Handler` | `PlaceOrderHandler` |
+| Projection | Noun describing the view | `OrderSummaryProjection` |
+
+Commands MUST NOT return domain data — return the new entity ID or void. Queries MUST NOT
+mutate state.
+
+## Structured Logging
+
+Use **pino** as the default structured logger. Never use `console.log`, `console.error`, or
+`console.warn` in application code (`console.*` is acceptable only in CLI tools and build
+scripts):
+
+```typescript
+import pino from "pino";
+const logger = pino();
+
+// In Express/Fastify middleware, attach a child logger per request:
+const reqLogger = logger.child({ request_id: req.id, user_id: req.user?.id });
+
+// Log with structured fields, not interpolated strings:
+reqLogger.info({ order_id: orderId, amount }, "order placed");
+reqLogger.error({ err, order_id: orderId }, "payment failed");
+```
+
+Never log variables whose names end in `password`, `secret`, `token`, `api_key`, `cookie`, or
+`authorization`.
+
+## React Guidelines
+
+- Use functional components with hooks exclusively. No class components.
+- Extract business logic into custom hooks or service functions — keep components presentational.
+- Use stable `data-testid` attributes for E2E test selectors; never match on CSS classes, DOM
+  hierarchy, or display text.
+- Props interfaces use `PascalCase`: `interface ButtonProps { ... }`. Co-locate with the
+  component file.
+- Do not import React explicitly (JSX transform handles it). Use `React.FC` only if required by
+  the project — prefer plain function declarations.
+
+## Error Handling
+
+- Use typed `Result` patterns or typed error unions rather than throwing for recoverable errors
+  at domain boundaries.
+- Always handle the error case explicitly — never use `.catch(() => {})` silently.
+- Fail fast with a clear, descriptive error when an invariant is violated.
+
+## Testing (Vitest / Jest)
+
+- Name tests as functional requirement specifications:
+  `it("submitting a valid order creates a confirmed record with correct totals")`.
+- Use `describe` blocks to group by feature or class under test.
+- Mock only external I/O (databases, HTTP, file system). Never mock domain logic.
+- Co-locate unit tests next to source files (`UserRepository.test.ts` beside
+  `UserRepository.ts`).
+- Mutation testing (Stryker) runs in CI for repos that configure it — write meaningful
+  assertions, not trivial coverage padding.
+
+## Electron-Specific (TalkTerm and desktop repos)
+
+- Keep main-process and renderer-process code strictly separated. Never import renderer modules
+  in the main process or vice versa.
+- Use `contextBridge` for all IPC; never expose `ipcRenderer` directly to renderer code.
+- Validate all data crossing the IPC bridge as if it were external user input.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -89,15 +89,15 @@ Use **pino** as the default structured logger. Never use `console.log`, `console
 scripts):
 
 ```typescript
-import pino from "pino";
+import pino from 'pino';
 const logger = pino();
 
 // In Express/Fastify middleware, attach a child logger per request:
 const reqLogger = logger.child({ request_id: req.id, user_id: req.user?.id });
 
 // Log with structured fields, not interpolated strings:
-reqLogger.info({ order_id: orderId, amount }, "order placed");
-reqLogger.error({ err, order_id: orderId }, "payment failed");
+reqLogger.info({ order_id: orderId, amount }, 'order placed');
+reqLogger.error({ err, order_id: orderId }, 'payment failed');
 ```
 
 Never log variables whose names end in `password`, `secret`, `token`, `api_key`, `cookie`, or


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-instructions.md` customized for markets' Expo + Go stack
- Copies `typescript.instructions.md`, `javascript.instructions.md`, `go.instructions.md`, and `shell.instructions.md` from the org canonical source
- Covers: Expo Router role-based layout, Gluestack UI v3 + NativeWind conventions, Figma MCP integration rules, Apollo Client + graphql-codegen workflow, Firebase auth, GCP Cloud Run backend

## Stack discovered

Expo SDK 55 · React Native · TypeScript · Expo Router · Gluestack UI v3 · NativeWind v4 · Apollo Client 4.x · graphql-codegen · Firebase Auth + Realtime DB · Go · gqlgen · Cloud SQL PostgreSQL · Jest (jest-expo) · MMKV · ESLint + Prettier

## References

- Org-wide rollout: petry-projects/.github PR #328
- Org baseline: [petry-projects/.github copilot-instructions.md](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development standards guides for Go, JavaScript, TypeScript, and shell scripts, covering style conventions, formatting, linting, naming patterns, testing practices, and security guidelines
  * Added project-specific Copilot instructions with repository architecture, tech stack, development setup, and environment configuration details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/markets/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->