### PR TITLE
fix(dev-lead): grant statuses:read + centralise concurrency

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -37,22 +37,9 @@ on:
 
 permissions: {}
 
-concurrency:
-  # Scoped per PR or issue so parallel PRs/issues run concurrently instead of
-  # queuing behind a single global slot (which caused >50% cancellations).
-  # ci-relay (check_run) keeps an ephemeral per-SHA slot so it fires immediately
-  # without blocking or being blocked by the per-PR/issue queue.
-  group: >-
-    ${{
-      github.event_name == 'check_run'                   && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
-      github.event_name == 'pull_request'                && format('dev-lead-pr-{0}', github.event.pull_request.number) ||
-      github.event_name == 'pull_request_review'         && format('dev-lead-pr-{0}', github.event.pull_request.number) ||
-      github.event_name == 'pull_request_review_comment' && format('dev-lead-pr-{0}', github.event.pull_request.number) ||
-      github.event_name == 'issue_comment'               && format('dev-lead-issue-{0}', github.event.issue.number) ||
-      github.event_name == 'issues'                      && format('dev-lead-issue-{0}', github.event.issue.number) ||
-      'dev-lead'
-    }}
-  cancel-in-progress: false
+# Concurrency is centralised in the reusable workflow (dev-lead-reusable.yml) with
+# per-issue / per-PR lanes (this repo's prior local fix), so issue pickups are never
+# cancelled by PR follow-up traffic and the grouping can't drift. See petry-projects/.github#402.
 
 jobs:
   dev-lead:
@@ -64,3 +51,4 @@ jobs:
       issues: write
       actions: read
       checks: read
+      statuses: read   # required by dev-lead-reusable.yml since #435


### PR DESCRIPTION
Two fixes:

1. **`statuses: read`** — this caller pins `@main` but grants no `statuses`, so it will `startup_failure` on its next dispatch event (latent — not yet observed). Required by the reusable since #435.
2. **Remove this repo's local per-PR/issue concurrency block** — the same (good) routing now lives centrally in `dev-lead-reusable.yml`, so it can't drift. No behaviour regression.

Refs petry-projects/.github#402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)