### PR TITLE
fix(dev-lead): pin to @dev-lead/stable channel + agent_ref (#557)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -43,7 +43,9 @@ permissions: {}
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@7b0426146444d97550dcca89d86984b809288506 # main
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    with:
+      agent_ref: dev-lead/stable
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Convert this repo's `dev-lead.yml` from `dev-lead-reusable.yml@main` → `@dev-lead/stable` + `agent_ref: dev-lead/stable`, so dev-lead runs the pinned known-good channel and promotion is a central tag move (no caller churn). `dev-lead/stable` is at v1.2.0 (= main, incl. #488 fixes) — no behavior change today, just version pinning. Part of #557 (dev-lead consumer fan-out), mirroring #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)