### PR TITLE
fix(dev-lead): restore @dev-lead/stable pin (revert broken #265 ref)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -43,7 +43,9 @@ permissions: {}
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github/.github/workflows/dev-lead-reusable.yml@v1
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    with:
+      agent_ref: dev-lead/stable
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Problem
PR #265 ("Compliance: non-stub-dev-lead.yml", issue #216) repointed `dev-lead.yml` to `petry-projects/.github/.github/workflows/dev-lead-reusable.yml@v1` — **which does not exist** (404; the dev-lead reusable lives in `.github-private`, not public `.github`). Result: **every markets dev-lead run has failed at startup** (unresolvable reusable, `jobs:[]`) since #265 merged at 2026-06-11T09:22Z.

## Fix
Restore the correct pin (set by #264, required by the ratified standard petry-projects/.github#440 and its updated `check_dev_lead_stub`):
```yaml
uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
with:
  agent_ref: dev-lead/stable
secrets: inherit
```
Matches the other 3 consumers (ContentTwin/google-app-scripts/bmad), which were unaffected. With #440 merged, the compliance audit now expects `@dev-lead/stable`, so this should not recur.

Found by the post-implementation health check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)